### PR TITLE
Change path of config.js file.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,2 @@
 target/
-config.js
+src/main/webapp/config.js

--- a/src/main/webapp/index.html
+++ b/src/main/webapp/index.html
@@ -7,7 +7,7 @@
     <link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/4.5.0/css/bootstrap.min.css" 
       integrity="sha384-9aIt2nRpC12Uk9gS9baDl411NQApFmC26EwAOH8WgZl5MYYxFfc+NcPb1dKGj7Sk" crossorigin="anonymous">
     <link rel="stylesheet" href="style.css">
-    <script src="../../config.js"></script>
+    <script src="config.js"></script>
     <script src="script.js"></script>
   </head>
   <body>

--- a/src/main/webapp/maps.html
+++ b/src/main/webapp/maps.html
@@ -7,7 +7,7 @@
     <link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/4.5.0/css/bootstrap.min.css" 
       integrity="sha384-9aIt2nRpC12Uk9gS9baDl411NQApFmC26EwAOH8WgZl5MYYxFfc+NcPb1dKGj7Sk" crossorigin="anonymous">
     <link rel="stylesheet" href="style.css">
-    <script src="../../config.js"></script>
+    <script src="config.js"></script>
     <script src="mapsScript.js"></script>
     <script src="authScript.js"></script>
   </head>


### PR DESCRIPTION
I had to change the path of the `config.js` file to the `src/main/webapp/` folder in order for the other files to be able to access this. It should work now.

Note: The reason it worked for me before is because in the process of placing the `config.js` file in different directories, the `target` folder built the `config.js` file into its package (wc?), and thus it was accessible by other files. I made sure this error wasn't the case this time by deleting the `target` folder before running `mvn package appengine:run`, so it had to re-build the project. 