### PR TITLE
Add Config.java file to .gitignore.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 target/
 src/main/webapp/config.js
+src/main/java/com/google/sps/data/Config.java


### PR DESCRIPTION
While the `config.js` file works to hide and get the API key for files on the frontend (HTML/CSS/JavaScript), it cannot be accessed from the backend (Java). Since @eshika needs the API key in the backend to use the Google Maps Java Client, this CL will allow her to do so while still hiding the API key.

Therefore, this CL just adds a `.gitignore` to hide the `Config.java` file from Github.

In order to access the API key, add this import to your code:

`import com.google.sps.data.Config;`

And then, you can access the file with the variable `Config.API_KEY`.