### PR TITLE
Add Trip Entity objects to datastore upon homepage form submission.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 target/
 src/main/webapp/config.js
+src/main/java/com/google/sps/data/Config.java

--- a/pom.xml
+++ b/pom.xml
@@ -67,7 +67,19 @@
     <dependency>
       <groupId>org.mockito</groupId>
       <artifactId>mockito-core</artifactId>
-      <version>2.0.5-beta</version>
+      <version>2.18.0</version>
+    </dependency>
+
+    <dependency>
+      <groupId>org.powermock</groupId>
+      <artifactId>powermock-api-mockito2</artifactId>
+      <version>2.0.0-beta.5</version>
+    </dependency>
+
+    <dependency>
+      <groupId>org.powermock</groupId>
+      <artifactId>powermock-module-junit4</artifactId>
+      <version>2.0.0-beta.5</version>
     </dependency>
 
     <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -70,6 +70,12 @@
       <version>2.0.5-beta</version>
     </dependency>
 
+    <dependency>
+      <groupId>com.google.maps</groupId>
+      <artifactId>google-maps-services</artifactId>
+      <version>0.14.0</version>
+    </dependency>
+
   </dependencies>
 
   <build>

--- a/src/main/java/com/google/sps/Trip.java
+++ b/src/main/java/com/google/sps/Trip.java
@@ -41,13 +41,13 @@ public class Trip {
   private int numDays;
 
   // Constants to get and put the Entity objects in Datastore.
-  private static final String TRIP = "trip";
-  private static final String TRIP_NAME = "trip_name";
-  private static final String DESTINATION_NAME = "destination_name";
-  private static final String TRIP_KEY = "trip_key";
-  private static final String IMAGE_SRC = "image_src";
-  private static final String START_DATE = "start_date";
-  private static final String END_DATE = "end_date";
+  public static final String TRIP = "trip";
+  public static final String TRIP_NAME = "trip_name";
+  public static final String DESTINATION_NAME = "destination_name";
+  public static final String TRIP_KEY = "trip_key";
+  public static final String IMAGE_SRC = "image_src";
+  public static final String START_DATE = "start_date";
+  public static final String END_DATE = "end_date";
 
   /**
    * Creates a new Trip.

--- a/src/main/java/com/google/sps/data/User.java
+++ b/src/main/java/com/google/sps/data/User.java
@@ -28,6 +28,8 @@ public class User {
   /**
    * Constructor to create a User object; the userId is generated automatically,
    * and the trip IDs are added to the User after constructing the object.
+   *
+   * @param email The email of the user.
    */
   public User(String email) {
     this.email = email;

--- a/src/main/java/com/google/sps/servlets/AuthServlet.java
+++ b/src/main/java/com/google/sps/servlets/AuthServlet.java
@@ -52,6 +52,11 @@ public class AuthServlet extends HttpServlet {
 
   /**
    * Write the UserAuth object in JSON form through response.
+   *
+   * @param response The HttpServletResponse used to write the user 
+   * authentication information.
+   * @param userService The UserService object that holds the user's current
+   * login information.
    */
   public void writeToUserAuthResponse(HttpServletResponse response, UserService userService) throws IOException {
     // Create UserAuth object with relevant login / logout information.
@@ -90,6 +95,8 @@ public class AuthServlet extends HttpServlet {
    * If the user is not in database already, add them.
    * This method returns the Entity object in the database (or the newly-created
    * user Entity, if none previously existed).
+   *
+   * @param email The email of the user in the database, or to-be-added.
    */
   public static Entity getOrCreateUserInDatabase(String email) {
     DatastoreService datastore = DatastoreServiceFactory.getDatastoreService();
@@ -134,6 +141,8 @@ public class AuthServlet extends HttpServlet {
   /**
    * Return Entity object of user from database using email, or null if user 
    * email is not in db.
+   *
+   * @param email The email of the user potentially in the database.
    */
   public static Entity getUserEntityFromEmail(String email) {
     // Query database to see if User has already been added.

--- a/src/main/java/com/google/sps/servlets/TripServlet.java
+++ b/src/main/java/com/google/sps/servlets/TripServlet.java
@@ -34,7 +34,8 @@ import javax.servlet.http.HttpServletResponse;
 public class TripServlet extends HttpServlet {
 
   // Create the GeoApiContext object.
-  GeoApiContext context;
+  private GeoApiContext context;
+  private int photoSrcSize = 400;
 
   // Constants to get form inputs.
   private static final String INPUT_TRIP_NAME = "inputTripName";
@@ -147,7 +148,7 @@ public class TripServlet extends HttpServlet {
         this.photoSrc = "../images/placeholder_image.png";
       } else {
         Photo photoObject = placeDetailsResult.photos[0];
-        this.photoSrc = getUrlFromPhotoReference(400, photoObject.photoReference);
+        this.photoSrc = getUrlFromPhotoReference(this.photoSrcSize, photoObject.photoReference);
       }
     }
   }
@@ -177,6 +178,10 @@ public class TripServlet extends HttpServlet {
    * Get a URL to show the photo from the photoreference.
    * See https://developers.google.com/places/web-service/photos#place_photo_requests
    * for more info.
+   * 
+   * @param maxWidth This is the maximum width of the image.
+   * @param photoReference This is the photo reference String stored in the 
+   * Google Maps Photo object; this is used to retrieve the actual photo URL.
    */
   public String getUrlFromPhotoReference(int maxWidth, String photoReference) {
     final String baseUrl = "https://maps.googleapis.com/maps/api/place/photo?";

--- a/src/main/java/com/google/sps/servlets/TripServlet.java
+++ b/src/main/java/com/google/sps/servlets/TripServlet.java
@@ -97,8 +97,6 @@ public class TripServlet extends HttpServlet {
     try {
       FindPlaceFromText findPlaceResult = findPlaceRequest.await();
 
-      System.err.println(findPlaceRequest);
-
       // Return place ID of the first candidate result.
       if (findPlaceResult.candidates != null) {
         return findPlaceResult.candidates[0].placeId;

--- a/src/main/java/com/google/sps/servlets/TripServlet.java
+++ b/src/main/java/com/google/sps/servlets/TripServlet.java
@@ -137,7 +137,7 @@ public class TripServlet extends HttpServlet {
     String destinationPlaceId = getPlaceIdFromTextSearch(context, this.tripDestination);
     if (destinationPlaceId == null) {
       this.destinationName = tripDestination;
-      this.photoSrc = "images/placeholder_image.png";
+      this.photoSrc = "../images/placeholder_image.png";
     } else {
       PlaceDetails placeDetailsResult = getPlaceDetailsFromPlaceId(context, destinationPlaceId);
 

--- a/src/main/java/com/google/sps/servlets/TripServlet.java
+++ b/src/main/java/com/google/sps/servlets/TripServlet.java
@@ -131,6 +131,11 @@ public class TripServlet extends HttpServlet {
   /**
    * Get the place ID of the text search. Return null if no place ID matches
    * the search.
+   * 
+   * @param context The entry point for making requests against the Google Geo 
+   * APIs (googlemaps.github.io/google-maps-services-java/v0.1.2/javadoc/com/google/maps/GeoApiContext.html).
+   * @param textSearch The text query to be entered in the findPlaceFromText(...)
+   * API call. Must be non-null.
    */ 
   public String getPlaceIdFromTextSearch(GeoApiContext context, String textSearch) 
     throws IOException {
@@ -261,6 +266,16 @@ public class TripServlet extends HttpServlet {
   /**
    * Store the Trip Entity in datastore with the User Entity as an ancestor.
    * Return the Trip Entity object.
+   * 
+   * @param response The HttpServletResponse used to redirect to homepage if
+   * no user is logged in. 
+   * @param tripName The human-readable name for the trip. Must be non-null.
+   * @param destinationName The name of the destination the user is heading to.
+   * This destination should be verified by the Google Maps API.
+   * @param tripDayOfTravel The date of the trip. Must be in yyyy-MM-dd date format.
+   * @param photoSrc The image source / URL to represent the trip. This is 
+   * typically retrieved using the Places API to get a photo from the destination
+   * name, but can also be the placeholder image source if no photo exists.
    */
   public Entity storeTripEntity(HttpServletResponse response, String tripName, 
     String destinationName, String tripDayOfTravel, String photoSrc) throws IOException {

--- a/src/main/java/com/google/sps/servlets/TripServlet.java
+++ b/src/main/java/com/google/sps/servlets/TripServlet.java
@@ -54,7 +54,7 @@ public class TripServlet extends HttpServlet {
 
   // Create the GeoApiContext object.
   private GeoApiContext context;
-  private int photoSrcSize = 400;
+  private static final int PHOTO_SRC_SIZE = 400;
 
   // Constants to get form inputs.
   private static final String INPUT_TRIP_NAME = "inputTripName";
@@ -218,7 +218,7 @@ public class TripServlet extends HttpServlet {
   /**
    * Get the PlaceDetails object from the place ID.
    */
-  public PlaceDetails getPlaceDetailsFromPlaceId(GeoApiContext context, String placeId)
+  private PlaceDetails getPlaceDetailsFromPlaceId(GeoApiContext context, String placeId)
     throws IOException {
 
     PlaceDetailsRequest placeDetailsRequest = PlacesApi.placeDetails(context, 
@@ -233,7 +233,7 @@ public class TripServlet extends HttpServlet {
   /**
    * Populate the destinationName and photoSrc fields using the Google Maps API.
    */
-  public void populateDestinationAndPhoto(GeoApiContext context, String tripDestination)
+  private void populateDestinationAndPhoto(GeoApiContext context, String tripDestination)
     throws IOException {
 
     // Get place ID from search of trip destination. Get photo and destination 
@@ -253,7 +253,7 @@ public class TripServlet extends HttpServlet {
         this.photoSrc = "../images/placeholder_image.png";
       } else {
         Photo photoObject = placeDetailsResult.photos[0];
-        this.photoSrc = getUrlFromPhotoReference(this.photoSrcSize, photoObject.photoReference);
+        this.photoSrc = getUrlFromPhotoReference(PHOTO_SRC_SIZE, photoObject.photoReference);
       }
     }
   }
@@ -265,7 +265,6 @@ public class TripServlet extends HttpServlet {
   public Entity storeTripEntity(HttpServletResponse response, String tripName, 
     String destinationName, String tripDayOfTravel, String photoSrc) throws IOException {
     // Get User Entity. If user not logged in, redirect to homepage.
-    DatastoreService datastore = DatastoreServiceFactory.getDatastoreService();
     Entity userEntity = AuthServlet.getCurrentUserEntity();
     if (userEntity == null) {
       response.sendRedirect("/");
@@ -273,6 +272,7 @@ public class TripServlet extends HttpServlet {
     }
 
     // Put Trip Entity into datastore.
+    DatastoreService datastore = DatastoreServiceFactory.getDatastoreService();
     Entity tripEntity = Trip.buildEntity(tripName, destinationName, photoSrc,
       tripDayOfTravel, tripDayOfTravel, userEntity.getKey());
     datastore.put(tripEntity);
@@ -288,7 +288,7 @@ public class TripServlet extends HttpServlet {
    * @param photoReference This is the photo reference String stored in the 
    * Google Maps Photo object; this is used to retrieve the actual photo URL.
    */
-  public String getUrlFromPhotoReference(int maxWidth, String photoReference) {
+  private String getUrlFromPhotoReference(int maxWidth, String photoReference) {
     final String baseUrl = "https://maps.googleapis.com/maps/api/place/photo?";
     return baseUrl + "maxwidth=" + maxWidth + "&photoreference=" + 
       photoReference + "&key=" + Config.API_KEY;

--- a/src/main/java/com/google/sps/servlets/TripServlet.java
+++ b/src/main/java/com/google/sps/servlets/TripServlet.java
@@ -8,6 +8,21 @@
 
 package com.google.sps.servlets;
 
+import com.google.appengine.api.datastore.DatastoreService;
+import com.google.appengine.api.datastore.DatastoreServiceFactory;
+import com.google.appengine.api.datastore.Entity;
+import com.google.maps.errors.ApiException;
+import com.google.maps.FindPlaceFromTextRequest;
+import com.google.maps.GeoApiContext;
+import com.google.maps.PlaceDetailsRequest;
+import com.google.maps.PlacesApi;
+import com.google.maps.model.FindPlaceFromText;
+import com.google.maps.model.LatLng;
+import com.google.maps.model.Photo;
+import com.google.maps.model.PlaceDetails;
+import com.google.maps.model.PlaceType;
+import com.google.sps.data.Config;
+import com.google.sps.Trip;
 import java.io.IOException;
 import java.util.Enumeration;
 import javax.servlet.annotation.WebServlet;
@@ -18,16 +33,118 @@ import javax.servlet.http.HttpServletResponse;
 @WebServlet("/calculate-trip")
 public class TripServlet extends HttpServlet {
 
+  // Constants to get form inputs.
+  private static final String INPUT_TRIP_NAME = "inputTripName";
+  private static final String INPUT_DESTINATION = "inputDestination";
+  private static final String INPUT_DAY_OF_TRAVEL = "inputDayOfTravel";
+
+  // Trip attributes
+
   @Override
   public void doPost(HttpServletRequest request, HttpServletResponse response) throws IOException {
     response.setContentType("application/json;");
 
+    // Retrieve form inputs to define the Trip object.
+    String tripName = request.getParameter(INPUT_TRIP_NAME);
+    String tripDestination = request.getParameter(INPUT_DESTINATION);
+    String tripDayOfTravel = request.getParameter(INPUT_DAY_OF_TRAVEL);
+
+    GeoApiContext context = new GeoApiContext.Builder()
+      .apiKey(Config.API_KEY)
+      .build();
+
+    // Get place ID from search of trip destination. Get photo and destination 
+    // if not null; otherwise, use a placeholder photo and destination.
+    String destinationPlaceId = getPlaceIdFromTextSearch(context, tripDestination);
+    String destinationName;
+    String photoSrc;
+    if (destinationPlaceId == null) {
+      destinationName = tripDestination;
+      photoSrc = "images/placeholder_image.png";
+    } else {
+      PlaceDetails placeDetailsResult = getPlaceDetailsFromPlaceId(context, destinationPlaceId);
+
+      // Get the name of the location from the place details result.
+      destinationName = placeDetailsResult.name;
+
+      // Get a photo of the location from the place details result.
+      if (placeDetailsResult.photos == null) {
+        photoSrc = "images/placeholder_image.png";
+      } else {
+        Photo photoObject = placeDetailsResult.photos[0];
+        photoSrc = getUrlFromPhotoReference(400, photoObject.photoReference);
+      }
+    }
+
+    // Get User Entity. If user not logged in, redirect to homepage.
+    DatastoreService datastore = DatastoreServiceFactory.getDatastoreService();
+    Entity userEntity = AuthServlet.getCurrentUserEntity(AuthServlet.getUserService());
+    if (userEntity == null) {
+      response.sendRedirect("/");
+    }
+
+    // Put Trip Entity into datastore.
+    Entity tripEntity = Trip.buildEntity(tripName, destinationName, photoSrc,
+      tripDayOfTravel, tripDayOfTravel, userEntity.getKey());
+    datastore.put(tripEntity);
+
     // Print out params to site to verify retrieval of "start trip" user input.
-    Enumeration<String> params = request.getParameterNames(); 
+    Enumeration<String> params = request.getParameterNames();
     while (params.hasMoreElements()) {
       String paramName = params.nextElement();
       response.getWriter().println(paramName + ": " + request.getParameter(paramName));
     }
+  }
+
+  /**
+   * Get the place ID of the text search. Return null if no place ID matches
+   * the search.
+   */ 
+  public String getPlaceIdFromTextSearch(GeoApiContext context, String textSearch) 
+    throws IOException {
+
+    FindPlaceFromTextRequest findPlaceRequest = PlacesApi.findPlaceFromText(context, 
+      textSearch, FindPlaceFromTextRequest.InputType.TEXT_QUERY);
+
+    try {
+      FindPlaceFromText findPlaceResult = findPlaceRequest.await();
+
+      // Return place ID of the first candidate result.
+      if (findPlaceResult.candidates != null) {
+        return findPlaceResult.candidates[0].placeId;
+      }
+      
+      // No candidate is given, so return null.
+      return null;
+    } catch(ApiException | InterruptedException e) {
+      throw new IOException(e);
+    }
+  }
+
+  /**
+   * Get the PlaceDetails object from the place ID.
+   */
+  public PlaceDetails getPlaceDetailsFromPlaceId(GeoApiContext context, String placeId)
+    throws IOException {
+
+    PlaceDetailsRequest placeDetailsRequest = PlacesApi.placeDetails(context, 
+      placeId);
+    try {
+      return placeDetailsRequest.await();
+    } catch(ApiException | InterruptedException e) {
+      throw new IOException(e);
+    }
+  }
+
+  /**
+   * Get a URL to show the photo from the photoreference.
+   * See https://developers.google.com/places/web-service/photos#place_photo_requests
+   * for more info.
+   */
+  public String getUrlFromPhotoReference(int maxWidth, String photoReference) {
+    final String baseUrl = "https://maps.googleapis.com/maps/api/place/photo?";
+    return baseUrl + "maxwidth=" + maxWidth + "&photoreference=" + 
+      photoReference + "&key=" + Config.API_KEY;
   }
 
 }

--- a/src/main/java/com/google/sps/servlets/TripServlet.java
+++ b/src/main/java/com/google/sps/servlets/TripServlet.java
@@ -79,7 +79,9 @@ public class TripServlet extends HttpServlet {
      * Below methods can also use the field variables fetched from request in 
      * the above code.
      */
-    
+
+    // Redirect to the "/trips/" page to show the trip that was added.
+    response.sendRedirect("/trips/");
   }
 
   /**
@@ -144,7 +146,7 @@ public class TripServlet extends HttpServlet {
 
       // Get a photo of the location from the place details result.
       if (placeDetailsResult.photos == null) {
-        this.photoSrc = "images/placeholder_image.png";
+        this.photoSrc = "../images/placeholder_image.png";
       } else {
         Photo photoObject = placeDetailsResult.photos[0];
         this.photoSrc = getUrlFromPhotoReference(400, photoObject.photoReference);

--- a/src/test/java/com/google/sps/AuthServletTest.java
+++ b/src/test/java/com/google/sps/AuthServletTest.java
@@ -107,12 +107,12 @@ public final class AuthServletTest {
 
     // Create the expected JSON logged-in string.
     String expectedJson = "{\"url\":\"" + LOGOUT_URL_UNICODE + "\",\"email\":\"" 
-      + EMAIL + "\"}";
+      + EMAIL + "\"}\n";
 
     // Run getUserAuthJson(...), and test whether output matches expected.
     authServlet.getUserAuthJson(responseMock, userServiceMock);
     writer.flush();
-    Assert.assertTrue(stringWriter.toString().contains(expectedJson));
+    Assert.assertEquals(expectedJson, stringWriter.toString());
   }
 
   @Test
@@ -131,12 +131,12 @@ public final class AuthServletTest {
     when(responseMock.getWriter()).thenReturn(writer);
 
     // Create the expected JSON logged-out string.
-    String expectedJson = "{\"url\":\"" + LOGIN_URL_UNICODE + "\"}";
+    String expectedJson = "{\"url\":\"" + LOGIN_URL_UNICODE + "\"}\n";
 
     // Run getUserAuthJson()(...), and test whether output matches expected.
     authServlet.getUserAuthJson(responseMock, userServiceMock);
     writer.flush();
-    Assert.assertTrue(stringWriter.toString().contains(expectedJson));
+    Assert.assertEquals(expectedJson, stringWriter.toString());
   }
 
   @Test

--- a/src/test/java/com/google/sps/TripServletTest.java
+++ b/src/test/java/com/google/sps/TripServletTest.java
@@ -1,0 +1,233 @@
+// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.google.sps;
+
+import com.google.appengine.api.datastore.DatastoreService;
+import com.google.appengine.api.datastore.DatastoreServiceFactory;
+import com.google.appengine.api.datastore.Entity;
+import com.google.appengine.api.datastore.FetchOptions;
+import com.google.appengine.api.datastore.PreparedQuery;
+import com.google.appengine.api.datastore.Query;
+import com.google.appengine.api.users.UserService;
+import com.google.appengine.api.users.UserServiceFactory;
+import com.google.appengine.tools.development.testing.LocalDatastoreServiceTestConfig;
+import com.google.appengine.tools.development.testing.LocalServiceTestHelper;
+import com.google.maps.FindPlaceFromTextRequest;
+import com.google.maps.GeoApiContext;
+import com.google.maps.PlaceDetailsRequest;
+import com.google.maps.PlacesApi;
+import com.google.maps.model.FindPlaceFromText;
+import com.google.maps.model.PlaceDetails;
+import com.google.maps.model.PlacesSearchResult;
+import com.google.sps.Trip;
+import com.google.sps.data.User;
+import com.google.sps.servlets.AuthServlet;
+import com.google.sps.servlets.TripServlet;
+import java.io.PrintWriter;
+import java.io.StringWriter;
+import java.util.ArrayList;
+import java.util.List;
+import javax.servlet.http.HttpServlet;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+import static org.mockito.Mockito.*;
+import org.powermock.api.mockito.PowerMockito;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.PowerMockRunner;
+
+@RunWith(PowerMockRunner.class)
+@PrepareForTest({PlacesApi.class,FindPlaceFromTextRequest.class,UserServiceFactory.class})
+public final class TripServletTest {
+
+  // Constants to pass into PlacesApi methods.
+  private static final String TEXT_LOCATION_SEARCH = "Big Island, Hawaii, USA";
+  private static final String PLACE_ID = "ChIJWTr3xcHnU3kRNIHX-ZKkVRQ";
+
+  // Add constants necessary to testing retrieval of the current User.
+  public static final String EMAIL = "testemail@gmail.com";
+  public static final String AUTH_DOMAIN = "gmail.com";
+  public static final String LOGOUT_URL = "/_ah/logout?continue=%2F";
+  public static final String LOGIN_URL = "/_ah/login?continue=%2F";
+
+  // Create TripServlet object.
+  TripServlet tripServlet;
+
+  // Add helper to allow datastore testing in local JUnit tests.
+  // See https://cloud.google.com/appengine/docs/standard/java/tools/localunittesting.
+  private final LocalServiceTestHelper helper =
+    new LocalServiceTestHelper(new LocalDatastoreServiceTestConfig());
+
+  @Before
+  public void initTripServlet() {
+    tripServlet = new TripServlet();
+  }
+
+  @Before
+  public void setUp() {
+    helper.setUp();
+  }
+
+  @After
+  public void tearDown() {
+    helper.tearDown();
+  }
+
+  @Test
+  public void testGetPlaceIdFromTextSearchCandidatesPresent() throws Exception {
+    // Mock the GeoApiContext object to be passed into PlacesApi methods,
+    // and the FindPlaceFromTextRequest.
+    GeoApiContext mockGeoApiContext = mock(GeoApiContext.class);
+    FindPlaceFromTextRequest findPlaceRequest = 
+      PowerMockito.mock(FindPlaceFromTextRequest.class);
+
+    // Create the FindPlaceFromText object with a valid place ID.
+    FindPlaceFromText findPlaceResult = new FindPlaceFromText();
+    findPlaceResult.candidates = new PlacesSearchResult[1];
+    findPlaceResult.candidates[0] = new PlacesSearchResult();
+    findPlaceResult.candidates[0].placeId = PLACE_ID;
+
+    // Have the findPlaceRequest.await() method return the FindPlaceFromText
+    // object using PowerMockito, as await() is a final method.
+    PowerMockito.when(findPlaceRequest.await()).thenReturn(findPlaceResult);
+
+    // Mock the PlacesApi object.
+    PowerMockito.mockStatic(PlacesApi.class);
+    when(PlacesApi.findPlaceFromText(any(), anyString(), any()))
+      .thenReturn(findPlaceRequest);
+
+    // Run the getPlaceIdFromTextSearch(...) method to test the result.
+    String placeIdResult = tripServlet.getPlaceIdFromTextSearch(mockGeoApiContext, 
+      TEXT_LOCATION_SEARCH);
+
+    // Confirm that the method returns the correct place ID.
+    Assert.assertEquals(PLACE_ID, placeIdResult);
+  }
+
+  @Test
+  public void testGetPlaceIdFromTextSearchCandidatesNull() throws Exception {
+    // Mock the GeoApiContext object to be passed into PlacesApi methods,
+    // and the FindPlaceFromTextRequest.
+    GeoApiContext mockGeoApiContext = mock(GeoApiContext.class);
+    FindPlaceFromTextRequest findPlaceRequest = 
+      PowerMockito.mock(FindPlaceFromTextRequest.class);
+
+    // Create the FindPlaceFromText object with no place ID.
+    FindPlaceFromText findPlaceResult = new FindPlaceFromText();
+
+    // Have the findPlaceRequest.await() method return the FindPlaceFromText
+    // object using PowerMockito, as await() is a final method.
+    PowerMockito.when(findPlaceRequest.await()).thenReturn(findPlaceResult);
+
+    // Mock the PlacesApi object.
+    PowerMockito.mockStatic(PlacesApi.class);
+    when(PlacesApi.findPlaceFromText(any(), anyString(), any()))
+      .thenReturn(findPlaceRequest);
+
+    // Run the getPlaceIdFromTextSearch(...) method to test the result.
+    String placeIdResult = tripServlet.getPlaceIdFromTextSearch(mockGeoApiContext, 
+      TEXT_LOCATION_SEARCH);
+
+    // Confirm that the method returns null.
+    Assert.assertNull(placeIdResult);
+  }
+
+  @Test
+  public void testStoreTripEntityLoggedIn() throws Exception {
+    // Mock response.      
+    HttpServletResponse responseMock = mock(HttpServletResponse.class);
+    
+    // Create Trip Entity properties.
+    final String tripName = "Family Vacation";
+    final String destinationName = "Island of Hawai'i";
+    final String tripDayOfTravel = "2020-07-17";
+    final String photoSrc = "../images/placeholder_image.png";
+
+    // Mock UserService methods as logged-in user.
+    UserService userServiceMock = mock(UserService.class);
+    when(userServiceMock.isUserLoggedIn()).thenReturn(true);
+    // This is the User object from Google Appengine (full path given to avoid
+    // confusion with local User.java file).
+    when(userServiceMock.getCurrentUser()).thenReturn(
+        new com.google.appengine.api.users.User(EMAIL, AUTH_DOMAIN));
+    when(userServiceMock.createLogoutURL(AuthServlet.redirectUrl)).thenReturn(LOGOUT_URL);
+
+    // PowerMock static getUserService() method, which is used to get the user.
+    PowerMockito.mockStatic(UserServiceFactory.class);
+    when(UserServiceFactory.getUserService()).thenReturn(userServiceMock);
+
+    // Run storeTripEntity(...), with the User logged in (so trip is stored).
+    Entity tripEntityReturn = tripServlet.storeTripEntity(responseMock,
+      tripName, destinationName, tripDayOfTravel, photoSrc);
+
+    // Retrieve the datastore results.
+    DatastoreService datastore = DatastoreServiceFactory.getDatastoreService();
+    Query query = new Query(Trip.TRIP);
+    PreparedQuery results = datastore.prepare(query);
+    List<Entity> listResults = results.asList(FetchOptions.Builder.withDefaults());
+
+    // Check whether the proper Entity and count were returned.
+    Assert.assertEquals(1, listResults.size());
+    Assert.assertEquals(tripName, listResults.get(0).getProperty(Trip.TRIP_NAME));
+    Assert.assertEquals(destinationName, listResults.get(0).getProperty(Trip.DESTINATION_NAME));
+    Assert.assertEquals(tripDayOfTravel, listResults.get(0).getProperty(Trip.START_DATE));
+    Assert.assertEquals(tripDayOfTravel, listResults.get(0).getProperty(Trip.END_DATE));
+    Assert.assertEquals(photoSrc, listResults.get(0).getProperty(Trip.IMAGE_SRC));
+    
+    // Confirm that the Entity in the database matches the method return.
+    Assert.assertEquals(listResults.get(0), tripEntityReturn);
+  }
+
+  @Test
+  public void testStoreTripEntityNotLoggedIn() throws Exception {
+    // Mock response.      
+    HttpServletResponse responseMock = mock(HttpServletResponse.class);
+    
+    // Create Trip Entity properties.
+    final String tripName = "Family Vacation";
+    final String destinationName = "Island of Hawai'i";
+    final String tripDayOfTravel = "2020-07-17";
+    final String photoSrc = "../images/placeholder_image.png";
+
+    // Mock UserService methods as logged-out user.
+    UserService userServiceMock = mock(UserService.class);
+    when(userServiceMock.isUserLoggedIn()).thenReturn(false);
+    when(userServiceMock.createLoginURL(AuthServlet.redirectUrl)).thenReturn(LOGIN_URL);
+
+    // PowerMock static getUserService() method, which is used to get the user.
+    PowerMockito.mockStatic(UserServiceFactory.class);
+    when(UserServiceFactory.getUserService()).thenReturn(userServiceMock);
+
+    // Run storeTripEntity(...), with the User logged in (so trip is stored).
+    Entity tripEntityReturn = tripServlet.storeTripEntity(responseMock,
+      tripName, destinationName, tripDayOfTravel, photoSrc);
+
+    // Retrieve the datastore results.
+    DatastoreService datastore = DatastoreServiceFactory.getDatastoreService();
+    Query query = new Query(User.USER);
+    PreparedQuery results = datastore.prepare(query);
+    List<Entity> listResults = results.asList(FetchOptions.Builder.withDefaults());
+
+    // Check whether the proper Entity and count were returned.
+    Assert.assertEquals(0, listResults.size());
+    Assert.assertNull(tripEntityReturn);
+  }
+
+}

--- a/src/test/java/com/google/sps/TripServletTest.java
+++ b/src/test/java/com/google/sps/TripServletTest.java
@@ -257,7 +257,7 @@ public final class TripServletTest {
     PowerMockito.mockStatic(UserServiceFactory.class);
     when(UserServiceFactory.getUserService()).thenReturn(userServiceMock);
 
-    // Run storeTripEntity(...), with the User logged in (so trip is stored).
+    // Run storeTripEntity(...), with the User not logged in (so nothing is stored).
     Entity tripEntityReturn = tripServlet.storeTripEntity(responseMock,
       tripName, destinationName, tripDayOfTravel, photoSrc);
 

--- a/src/test/java/com/google/sps/TripServletTest.java
+++ b/src/test/java/com/google/sps/TripServletTest.java
@@ -271,5 +271,4 @@ public final class TripServletTest {
     Assert.assertEquals(0, listResults.size());
     Assert.assertNull(tripEntityReturn);
   }
-
 }


### PR DESCRIPTION
### List of changes:
- Get form input from `/calculate-trip` POST request.
- Use the Google Maps Places Java Client API to get the `placeId` and **Place Details** of the `tripDestination`. This is used to get a **photo of the destination** and a **destination name**.
- Get the current logged-in User Entity from Datastore. Put the Trip Entity into Datastore, with the current logged-in User Entity as its ancestor.
- Add tests for the TripServlet class using Mockito and PowerMock (PowerMockito necessary for final and static methods).
- Redirect back to homepage if POST request is made with no user currently logged in.
- Add line in `.gitignore` to hide server-side `Config.java` file, which allows access to the Google Maps API in Java server-side files.

### Notes:
- In future CLs, lots of more code will be added to the `TripServlet.java` `doPost` method, so some merging decisions will need to be made that may lead to code restructuring.
- There is a possibility that the `tripKey` field of the Trip class should allowed to be `null`. This `tripKey` represents the **Key** of the Trip Entity in datastore, so if it is not yet in datastore, there should be no `tripKey`. However, I am operating with the assumption that the Trip should immediately be put in datastore before initialization, so I am leaving this unless there is an objection.
- I found that these methods may not be able to store POIs with non-English characters. This is interesting to note, but lower priority, so there's no action on this for now.
- The image source holds the API key (see the [Places API documentation](https://developers.google.com/places/web-service/photos#place_photo_requests) for why this is necessary).
- I resolved merge conflicts from master that get and post the events into / from Datastore in `TripServlet.java`; the trip form now redirects to the `"/trips/"` page after submission.

### Screencast:
[Storing Trip data in Datastore](https://screencast.googleplex.com/cast/NTIyMjE0MzU4OTYxMzU2OHw1NGFkNDAyYy01YQ)

### Images:
Image of local datastore service storing the Trip after input form submission (the API key in the photo URL is replaced with **HIDDEN_API_KEY** by directly editing the HTML of the page -- if you tested, you would see an actual API key there):
![image](https://user-images.githubusercontent.com/7987279/87362728-4aa45680-c524-11ea-8432-b6c80ed8e2a8.png)
Image of the photo URL in the above datastore example:
[Image of the Island of Hawai'i](https://lh3.googleusercontent.com/p/AF1QipM7tbCZOj_5SOft9cYgI7un3bmieieqvdYkCPT5=s1600-w400)
