### PR TITLE
Fetch and display trip map. 

### DIFF
--- a/src/main/java/com/google/sps/TripDay.java
+++ b/src/main/java/com/google/sps/TripDay.java
@@ -31,9 +31,9 @@ public class TripDay {
   private LocalDate date;
 
   // Entity params
-  private static final String ORIGIN = "origin";
-  private static final String DESTINATION = "destination";
-  private static final String DATE = "date";
+  public static final String ORIGIN = "origin";
+  public static final String DESTINATION = "destination";
+  public static final String DATE = "date";
   
   // query string
   public static final String QUERY_STRING = "trip-day";

--- a/src/main/java/com/google/sps/servlets/MapServlet.java
+++ b/src/main/java/com/google/sps/servlets/MapServlet.java
@@ -80,11 +80,14 @@ public class MapServlet extends HttpServlet {
     Entity tripEntity = tripResults.asSingleEntity();
 
     Query tripDayQuery = new Query(TripDay.QUERY_STRING, tripEntity.getKey());
+
+    System.err.println(tripEntity.getKey());
     PreparedQuery tripDayResults = datastore.prepare(tripDayQuery);
 
     int tripDayIndex = 0;
 
-    Entity tripDayEntity = tripDayResults.asList(FetchOptions.Builder.withLimit(10)).get(tripDayIndex);
+    // Post-MVP: change to select the desired tripDay 
+    Entity tripDayEntity = tripDayResults.asSingleEntity();
 
     List<String> locations = new ArrayList<>();
     locations.add((String) tripDayEntity.getProperty("origin"));

--- a/src/main/java/com/google/sps/servlets/MapServlet.java
+++ b/src/main/java/com/google/sps/servlets/MapServlet.java
@@ -84,12 +84,18 @@ public class MapServlet extends HttpServlet {
       DatastoreService datastore, Entity userEntity, Key tripEntityKey) throws IOException {
   
     // Get trip Entity based on trip key.
+    // Trip entity is needed to ensure that tripKey corresponds to a Trip under the current user.
     Filter tripKeyFilter =
       new FilterPredicate("__key__", FilterOperator.EQUAL, tripEntityKey);
     Query tripQuery = new Query(Trip.TRIP, userEntity.getKey());
     tripQuery.setFilter(tripKeyFilter);
     PreparedQuery tripResults = datastore.prepare(tripQuery);
     Entity tripEntity = tripResults.asSingleEntity();
+
+    // If no trip is found then redirect
+    if (tripEntity == null) {
+      response.redirect("/");
+    }
 
     // Get TripDay associated with the Trip.
     // Post-MVP: change to select the desired tripDay.

--- a/src/main/java/com/google/sps/servlets/MapServlet.java
+++ b/src/main/java/com/google/sps/servlets/MapServlet.java
@@ -81,7 +81,6 @@ public class MapServlet extends HttpServlet {
 
     Query tripDayQuery = new Query(TripDay.QUERY_STRING, tripEntity.getKey());
 
-    System.err.println(tripEntity.getKey());
     PreparedQuery tripDayResults = datastore.prepare(tripDayQuery);
 
     int tripDayIndex = 0;

--- a/src/main/java/com/google/sps/servlets/MapServlet.java
+++ b/src/main/java/com/google/sps/servlets/MapServlet.java
@@ -98,7 +98,6 @@ public class MapServlet extends HttpServlet {
     if (tripEntity == null) {
       response.sendRedirect("/");
       return "No trip found";
-      // response.getWriter().println("No trip found");
     } 
 
     // Get TripDay associated with the Trip.
@@ -121,7 +120,6 @@ public class MapServlet extends HttpServlet {
     }
 
     return convertToJson(locations);
-    // response.getWriter().println(convertToJson(locations));    
   }
 
   /**

--- a/src/main/java/com/google/sps/servlets/MapServlet.java
+++ b/src/main/java/com/google/sps/servlets/MapServlet.java
@@ -80,7 +80,7 @@ public class MapServlet extends HttpServlet {
   }
 
   /**
-   * Gets the locations and prints them to writer.
+   * Gets the locations and returns them as a JSON string.
    */
   public String doGetMap(HttpServletResponse response, 
       DatastoreService datastore, Entity userEntity, Key tripEntityKey) throws IOException {

--- a/src/main/java/com/google/sps/servlets/MapServlet.java
+++ b/src/main/java/com/google/sps/servlets/MapServlet.java
@@ -65,7 +65,8 @@ public class MapServlet extends HttpServlet {
       response.getWriter().println("No trip Key");
       response.sendRedirect("/trips/");
   
-    // if no user Entity return home.
+    // Redirects to sign in page if no user is signed in
+    // Otherwise redirects to create trips page
     } else if (userEntity == null) {
       response.getWriter().println("No current User");
       response.sendRedirect("/");

--- a/src/main/java/com/google/sps/servlets/MapServlet.java
+++ b/src/main/java/com/google/sps/servlets/MapServlet.java
@@ -49,18 +49,18 @@ public class MapServlet extends HttpServlet {
       throws IOException {
     response.setContentType("application/json;");
 
-    // Initialize Datastore
+    // Initialize Datastore.
     DatastoreService datastore = DatastoreServiceFactory.getDatastoreService();
 
-    // Get current user
+    // Get current user.
     Entity userEntity = AuthServlet.getCurrentUserEntity();
 
-    // if no tripKey return to trips page
+    // if no tripKey return to trips page.
     if (request.getParameter("tripKey") == null ){
       response.getWriter().println("No trip Key");
       response.sendRedirect("/trips/");
   
-    // if no user Entity return home
+    // if no user Entity return home.
     } else if (userEntity == null) {
       response.getWriter().println("No current User");
       response.sendRedirect("/");
@@ -74,12 +74,12 @@ public class MapServlet extends HttpServlet {
   }
 
   /**
-   * Gets the locations and prints them to writer
+   * Gets the locations and prints them to writer.
    */
   public void doGetMap(HttpServletResponse response, 
       DatastoreService datastore, Entity userEntity, Key tripEntityKey) throws IOException {
   
-    // get trip Entity based on trip key
+    // Get trip Entity based on trip key.
     Filter tripKeyFilter =
       new FilterPredicate("__key__", FilterOperator.EQUAL, tripEntityKey);
     Query tripQuery = new Query(Trip.TRIP, userEntity.getKey());
@@ -87,17 +87,17 @@ public class MapServlet extends HttpServlet {
     PreparedQuery tripResults = datastore.prepare(tripQuery);
     Entity tripEntity = tripResults.asSingleEntity();
 
-    // Get TripDay associated with the Trip
-    // Post-MVP: change to select the desired tripDay 
+    // Get TripDay associated with the Trip.
+    // Post-MVP: change to select the desired tripDay.
     Query tripDayQuery = new Query(TripDay.QUERY_STRING, tripEntity.getKey());
     PreparedQuery tripDayResults = datastore.prepare(tripDayQuery);
     Entity tripDayEntity = tripDayResults.asSingleEntity();
 
-    // Add origin as the first location
+    // Add origin as the first location.
     List<String> locations = new ArrayList<>();
     locations.add((String) tripDayEntity.getProperty("origin"));
 
-    // Add rest of POIs to locations list and write to writer
+    // Add rest of POIs to locations list and write to writer.
     Query locationsQuery = new Query(TripDay.LOCATION_ENTITY_TYPE, tripDayEntity.getKey());
     locationsQuery.addSort(TripDay.ORDER);
     PreparedQuery locationResults = datastore.prepare(locationsQuery); 

--- a/src/main/java/com/google/sps/servlets/MapServlet.java
+++ b/src/main/java/com/google/sps/servlets/MapServlet.java
@@ -98,7 +98,7 @@ public class MapServlet extends HttpServlet {
       response.sendRedirect("/");
     } else {
       // Get TripDay associated with the Trip.
-      // Post-MVP: change to select the desired tripDay.
+      // TODO(eshika): change to select the desired tripDay for multiday trips.
       Query tripDayQuery = new Query(TripDay.QUERY_STRING, tripEntity.getKey());
       PreparedQuery tripDayResults = datastore.prepare(tripDayQuery);
       Entity tripDayEntity = tripDayResults.asSingleEntity();

--- a/src/main/java/com/google/sps/servlets/MapServlet.java
+++ b/src/main/java/com/google/sps/servlets/MapServlet.java
@@ -110,8 +110,9 @@ public class MapServlet extends HttpServlet {
       // Add rest of POIs to locations list and write to writer.
       Query locationsQuery = new Query(TripDay.LOCATION_ENTITY_TYPE, tripDayEntity.getKey());
       locationsQuery.addSort(TripDay.ORDER);
-      PreparedQuery locationResults = datastore.prepare(locationsQuery); 
+      PreparedQuery locationResults = datastore.prepare(locationsQuery);
       for (Entity locationEntity : locationResults.asIterable()) {
+        // Gets location names as Strings (these names include the full address needed for routing)
         locations.add((String) locationEntity.getProperty(TripDay.NAME));
       }
       response.getWriter().println(convertToJson(locations));

--- a/src/main/java/com/google/sps/servlets/MapServlet.java
+++ b/src/main/java/com/google/sps/servlets/MapServlet.java
@@ -40,6 +40,8 @@ import javax.servlet.http.HttpServletResponse;
 @WebServlet("/get-map")
 public class MapServlet extends HttpServlet {
 
+  private final String TRIP_KEY_PARAM = "tripKey";
+
   /**
    * Checks for invalid cases (no user or tripKey).
    * Gets the locations from datastore and prints them to writer.
@@ -55,8 +57,11 @@ public class MapServlet extends HttpServlet {
     // Get current user.
     Entity userEntity = AuthServlet.getCurrentUserEntity();
 
+    // Get tripKey.
+    String stringTripKey = request.getParameter(TRIP_KEY_PARAM);
+
     // if no tripKey return to trips page.
-    if (request.getParameter("tripKey") == null ){
+    if (stringTripKey == null) {
       response.getWriter().println("No trip Key");
       response.sendRedirect("/trips/");
   
@@ -65,7 +70,6 @@ public class MapServlet extends HttpServlet {
       response.getWriter().println("No current User");
       response.sendRedirect("/");
     } else { 
-      String stringTripKey = request.getParameter("tripKey");
       Key tripKey = KeyFactory.stringToKey(stringTripKey);
 
       // Gets the locations from datastore and writes them to .../get-map
@@ -95,7 +99,7 @@ public class MapServlet extends HttpServlet {
 
     // Add origin as the first location.
     List<String> locations = new ArrayList<>();
-    locations.add((String) tripDayEntity.getProperty("origin"));
+    locations.add((String) tripDayEntity.getProperty(TripDay.ORIGIN));
 
     // Add rest of POIs to locations list and write to writer.
     Query locationsQuery = new Query(TripDay.LOCATION_ENTITY_TYPE, tripDayEntity.getKey());

--- a/src/main/java/com/google/sps/servlets/MapServlet.java
+++ b/src/main/java/com/google/sps/servlets/MapServlet.java
@@ -1,0 +1,100 @@
+// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+
+package com.google.sps.servlets;
+
+import com.google.appengine.api.datastore.DatastoreService;
+import com.google.appengine.api.datastore.DatastoreServiceFactory;
+import com.google.appengine.api.datastore.Key;
+import com.google.appengine.api.datastore.KeyFactory;
+import com.google.appengine.api.datastore.Entity;
+import com.google.appengine.api.datastore.FetchOptions;
+import com.google.appengine.api.datastore.PreparedQuery;
+import com.google.appengine.api.datastore.Query;
+import com.google.appengine.api.datastore.Query.Filter;
+import com.google.appengine.api.datastore.Query.FilterOperator;
+import com.google.appengine.api.datastore.Query.FilterPredicate;
+import com.google.gson.Gson;
+import com.google.sps.data.Event;
+import com.google.sps.Trip;
+import com.google.sps.TripDay;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import javax.servlet.annotation.WebServlet;
+import javax.servlet.http.HttpServlet;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+@WebServlet("/get-map")
+public class MapServlet extends HttpServlet {
+  @Override
+  public void doGet(HttpServletRequest request, HttpServletResponse response) 
+      throws IOException {
+    response.setContentType("application/json;");
+    DatastoreService datastore = DatastoreServiceFactory.getDatastoreService();
+    String stringTripKey = request.getParameter("tripKey");
+    Key tripKey = KeyFactory.stringToKey(stringTripKey);
+
+    // get current user
+    Entity userEntity = AuthServlet.getCurrentUserEntity();
+
+
+    if (userEntity == null) {
+      response.sendRedirect("/");
+    }
+
+    Filter tripKeyFilter =
+      new FilterPredicate("__key__", FilterOperator.EQUAL, tripKey);
+    Query tripQuery = new Query("trip", userEntity.getKey());
+    tripQuery.setFilter(tripKeyFilter);
+
+    PreparedQuery tripResults = datastore.prepare(tripQuery);
+    Entity tripEntity = tripResults.asSingleEntity();
+
+    if (tripEntity == null) {
+      throw new IllegalArgumentException("Trip does not exist");
+    }
+
+    Query tripDayQuery = new Query("trip-day", tripEntity.getKey());
+    PreparedQuery tripDayResults = datastore.prepare(tripDayQuery);
+
+    List<Entity> tripDayEntities = tripDayResults.asList(FetchOptions.Builder.withDefaults());
+    // For MVP: only one tripDay per trip, so get first tripDay.
+    Entity tripDayEntity = tripDayEntities.get(0);
+
+    String origin = (String) tripDayEntity.getProperty("origin");
+    Query locationsQuery = new Query("location", tripDayEntity.getKey());
+    PreparedQuery locationsResults = datastore.prepare(locationsQuery);
+    List<Entity> locationsEntities = locationsResults.asList(FetchOptions.Builder.withDefaults());
+    
+    List<String> locations = new ArrayList<>();
+    locations.add(origin);
+    for (Entity locationEntity : locationsEntities) {
+      locations.add((String) locationEntity.getProperty("name"));
+    }
+
+    response.getWriter().println(convertToJson(locations));
+  }
+
+  /**
+   * Converts list of location strings into a JSON string using the Gson library.
+   */
+  private String convertToJson(List<String> locations) {
+    Gson gson = new Gson();
+    String json = gson.toJson(locations);
+    return json;
+  }
+}

--- a/src/main/webapp/mapsScript.js
+++ b/src/main/webapp/mapsScript.js
@@ -25,10 +25,10 @@ var directionsRenderer;
 
 // Attach callback function to the `window` object
 window.initMap = function() {
-  // Manhattan coords
+  // initialize coords
   const coords = {lat: 0, lng: 0};
 
-  // Create map centered on Manhattan
+  // Create map centered on the (0, 0) coordinates
   map = new google.maps.Map(
       document.getElementById('routeMap'),
       {center: coords, 
@@ -44,29 +44,26 @@ window.initMap = function() {
   directionsRenderer.setMap(map);
   directionsRenderer.setPanel(document.getElementById('rightPanel'));
 
-  // Hard coded place IDs - will replace with user input
-  let timesSquareID = 'ChIJmQJIxlVYwokRLgeuocVOGVU';
-  let centralParkID = 'ChIJ4zGFAZpYwokRGUGph3Mf37k';
-  let worldTradeID = 'ChIJy7cGfBlawokR5l2e93hsoEA';
-  let empireStateID = 'ChIJtcaxrqlZwokRfwmmibzPsTU';
-  let hotelID = 'ChIJ68J3tfpYwokR2HaRoBcB4xg';
+  getLocations();
+}
 
-  // let locations = getLocations();
+function getLocations() {
+  const urlParams = new URLSearchParams(window.location.search);
+  const tripKey = urlParams.get('tripKey');
+  const tripKeyQuery = (tripKey != null && tripKey != '') ? '?tripKey=' + tripKey : '';
+  
+  fetch('/get-map' + tripKeyQuery).then(response => response.json()).then((locations) => {
+    showDirections(locations);
+  });
+}
 
-  // let origin = locations[0];
-  // console.log(origin);
+function showDirections(locations) {
+  let origin = locations[0];
+  let waypts = [];
 
-  // let waypts = [{location : {'placeId': worldTradeID}},
-  //               {location : {'placeId': empireStateID}},
-  //               {location : {'placeId': timesSquareID}},
-  //               {location : {'placeId': centralParkID}},
-  //             ];
-
-  let waypts = [{ location : "MoPOP, 5th Avenue North, Seattle, WA, USA"},
-                                    {location : "Space Needle, Broad Street, Seattle, WA, USA"},
-                                    {location : "Alki Beach, Seattle, WA, USA"}];
-
-  let origin = "The Westin Bellevue, Bellevue Way Northeast, Bellevue, WA, USA";
+  for (let i = 1; i < locations.length; i++) {
+    waypts.push({ location : locations[i]});
+  }
 
   // Create a DirectionsRequest with hotel as start/end and 
   // POIs as waypoints (stops on the route)
@@ -88,7 +85,3 @@ window.initMap = function() {
 
 // Append the 'script' element to 'head'
 document.head.appendChild(script);
-
-// function getLocations() {
-//   fetch('/get-map').then(response => response.json()).then(locations);
-// }

--- a/src/main/webapp/mapsScript.js
+++ b/src/main/webapp/mapsScript.js
@@ -56,17 +56,23 @@ window.initMap = function() {
   // let origin = locations[0];
   // console.log(origin);
 
-  let waypts = [{location : {'placeId': worldTradeID}},
-                {location : {'placeId': empireStateID}},
-                {location : {'placeId': timesSquareID}},
-                {location : {'placeId': centralParkID}},
-              ];
+  // let waypts = [{location : {'placeId': worldTradeID}},
+  //               {location : {'placeId': empireStateID}},
+  //               {location : {'placeId': timesSquareID}},
+  //               {location : {'placeId': centralParkID}},
+  //             ];
+
+  let waypts = [{ location : "MoPOP, 5th Avenue North, Seattle, WA, USA"},
+                                    {location : "Space Needle, Broad Street, Seattle, WA, USA"},
+                                    {location : "Alki Beach, Seattle, WA, USA"}];
+
+  let origin = "The Westin Bellevue, Bellevue Way Northeast, Bellevue, WA, USA";
 
   // Create a DirectionsRequest with hotel as start/end and 
   // POIs as waypoints (stops on the route)
   directionsService.route({
-    origin: {'placeId': hotelID},
-    destination: {'placeId': hotelID},
+    origin: origin,
+    destination: origin,
     waypoints: waypts,
     optimizeWaypoints: true,
     travelMode: 'DRIVING'
@@ -83,6 +89,6 @@ window.initMap = function() {
 // Append the 'script' element to 'head'
 document.head.appendChild(script);
 
-function getLocations() {
-  fetch('/get-map').then(response => response.json()).then(locations);
-}
+// function getLocations() {
+//   fetch('/get-map').then(response => response.json()).then(locations);
+// }

--- a/src/main/webapp/mapsScript.js
+++ b/src/main/webapp/mapsScript.js
@@ -44,10 +44,15 @@ window.initMap = function() {
   directionsRenderer.setMap(map);
   directionsRenderer.setPanel(document.getElementById('rightPanel'));
 
-  getLocations();
+  // Get locations from MapServlet and display directions on map.
+  displayRouteOnMap();
 }
 
-function getLocations() {
+/*
+ * Gets locations from MapServlet with the tripKey parameter.
+ * Calls showDirections to show the directions with those locations.
+ */
+function displayRouteOnMap() {
   const urlParams = new URLSearchParams(window.location.search);
   const tripKey = urlParams.get('tripKey');
   const tripKeyQuery = (tripKey != null && tripKey != '') ? '?tripKey=' + tripKey : '';
@@ -57,6 +62,11 @@ function getLocations() {
   });
 }
 
+/* 
+ * Parses locations, generations DirectionsRequest with those locations,
+ * and displays on map with DirectionsRenderer.
+ * locations is a list of String addresses where the first element is the origin/destination
+ */
 function showDirections(locations) {
   let origin = locations[0];
   let waypts = [];

--- a/src/main/webapp/mapsScript.js
+++ b/src/main/webapp/mapsScript.js
@@ -26,7 +26,7 @@ var directionsRenderer;
 // Attach callback function to the `window` object
 window.initMap = function() {
   // Manhattan coords
-  const coords = {lat: 40.771, lng: -73.974};
+  const coords = {lat: 0, lng: 0};
 
   // Create map centered on Manhattan
   map = new google.maps.Map(
@@ -50,6 +50,11 @@ window.initMap = function() {
   let worldTradeID = 'ChIJy7cGfBlawokR5l2e93hsoEA';
   let empireStateID = 'ChIJtcaxrqlZwokRfwmmibzPsTU';
   let hotelID = 'ChIJ68J3tfpYwokR2HaRoBcB4xg';
+
+  // let locations = getLocations();
+
+  // let origin = locations[0];
+  // console.log(origin);
 
   let waypts = [{location : {'placeId': worldTradeID}},
                 {location : {'placeId': empireStateID}},
@@ -77,3 +82,7 @@ window.initMap = function() {
 
 // Append the 'script' element to 'head'
 document.head.appendChild(script);
+
+function getLocations() {
+  fetch('/get-map').then(response => response.json()).then(locations);
+}

--- a/src/main/webapp/mapsScript.js
+++ b/src/main/webapp/mapsScript.js
@@ -71,7 +71,6 @@ function showDirections(locations) {
     origin: origin,
     destination: origin,
     waypoints: waypts,
-    optimizeWaypoints: true,
     travelMode: 'DRIVING'
   }, function(response, status) {
     // Show directions when found

--- a/src/test/java/com/google/sps/MapServletTest.java
+++ b/src/test/java/com/google/sps/MapServletTest.java
@@ -303,7 +303,6 @@ public final class MapServletTest {
     mapServlet.doGet(request, response);
 
     String expectedJson = "No trip found";
-    System.err.println(stringWriter.toString());
     Assert.assertTrue(stringWriter.toString().contains(expectedJson));
   }
 }

--- a/src/test/java/com/google/sps/MapServletTest.java
+++ b/src/test/java/com/google/sps/MapServletTest.java
@@ -115,15 +115,15 @@ public final class MapServletTest {
     datastore.put(tripDayEntity);
 
     // create location entities and put it into datastore
-    Entity DomeEntity = new Entity(TripDay.LOCATION_ENTITY_TYPE, tripDayEntity.getKey());
-    DomeEntity.setProperty(TripDay.NAME, DOME_ADDRESS);
-    DomeEntity.setProperty(TripDay.ORDER, 1);
-    datastore.put(DomeEntity);
+    Entity domeEntity = new Entity(TripDay.LOCATION_ENTITY_TYPE, tripDayEntity.getKey());
+    domeEntity.setProperty(TripDay.NAME, DOME_ADDRESS);
+    domeEntity.setProperty(TripDay.ORDER, 1);
+    datastore.put(domeEntity);
 
-    Entity YosemiteEntity = new Entity(TripDay.LOCATION_ENTITY_TYPE, tripDayEntity.getKey());
-    YosemiteEntity.setProperty(TripDay.NAME, YOSEMITE_ADDRESS);
-    YosemiteEntity.setProperty(TripDay.ORDER, 0);
-    datastore.put(YosemiteEntity);
+    Entity yosemiteEntity = new Entity(TripDay.LOCATION_ENTITY_TYPE, tripDayEntity.getKey());
+    yosemiteEntity.setProperty(TripDay.NAME, YOSEMITE_ADDRESS);
+    yosemiteEntity.setProperty(TripDay.ORDER, 0);
+    datastore.put(yosemiteEntity);
 
     // run do Get
     mapServlet.doGetMap(response, datastore, userEntity, tripEntity.getKey());

--- a/src/test/java/com/google/sps/MapServletTest.java
+++ b/src/test/java/com/google/sps/MapServletTest.java
@@ -43,15 +43,13 @@ public final class MapServletTest {
 
   private MapServlet mapServlet;
 
-  // class constants
-  private static final String INPUT_DESTINATION = 
-      "4265 24th Street San Francisco, CA, 94114";
-  private static final String INPUT_DATE = "2020-07-15";
+  // User constants
   private static final String EMAIL = "test123@gmail.com";
 
   // Constants to represent different Trip attributes.
   private static final String TRIP_NAME = "Trip to California";
-  private static final String DESTINATION_NAME = "California";
+  private static final String INPUT_DESTINATION = 
+      "4265 24th Street San Francisco, CA, 94114";
   private static final String IMAGE_SRC =
     "https://lh3.googleusercontent.com/p/AF1QipM7tbCZOj_5SOft9cYgI7un3bmieieqvdYkCPT5=s1600-w400";
   private static final String TRIP_DAY_OF_TRAVEL = "2020-02-29";
@@ -103,7 +101,7 @@ public final class MapServletTest {
     // Add a single Trip to Datastore with the User Entity Key.
     Entity tripEntity = new Entity(Trip.TRIP, userEntityKey);
     tripEntity.setProperty(Trip.TRIP_NAME, TRIP_NAME);
-    tripEntity.setProperty(Trip.DESTINATION_NAME, DESTINATION_NAME);
+    tripEntity.setProperty(Trip.DESTINATION_NAME, INPUT_DESTINATION);
     tripEntity.setProperty(Trip.IMAGE_SRC, IMAGE_SRC);
     tripEntity.setProperty(Trip.START_DATE, TRIP_DAY_OF_TRAVEL);
     tripEntity.setProperty(Trip.END_DATE, TRIP_DAY_OF_TRAVEL);
@@ -113,7 +111,7 @@ public final class MapServletTest {
     Entity tripDayEntity = new Entity(TripDay.QUERY_STRING, tripEntity.getKey());
     tripDayEntity.setProperty("origin", INPUT_DESTINATION);
     tripDayEntity.setProperty("destination", INPUT_DESTINATION);
-    tripDayEntity.setProperty("date", INPUT_DATE);
+    tripDayEntity.setProperty("date", TRIP_DAY_OF_TRAVEL);
     datastore.put(tripDayEntity);
 
     // create location entities and put it into datastore
@@ -130,6 +128,8 @@ public final class MapServletTest {
     // run do Get
     mapServlet.doGetMap(response, datastore, userEntity, tripEntity.getKey());
 
+    // even though DomeEntity is added first, its order property is 1 so it should appear 
+    // after YosemiteEntity in the JSON.
     String expectedJson = "[\"" + INPUT_DESTINATION + "\",\""+YOSEMITE_ADDRESS+"\",\""+DOME_ADDRESS+"\"]";
     
     writer.flush();

--- a/src/test/java/com/google/sps/MapServletTest.java
+++ b/src/test/java/com/google/sps/MapServletTest.java
@@ -1,0 +1,186 @@
+// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.google.sps;
+
+import static org.mockito.Mockito.*;
+import com.google.appengine.api.datastore.DatastoreService;
+import com.google.appengine.api.datastore.DatastoreServiceFactory;
+import com.google.appengine.api.datastore.Entity;
+import com.google.appengine.api.datastore.Key;
+import com.google.appengine.tools.development.testing.LocalDatastoreServiceTestConfig;
+import com.google.appengine.tools.development.testing.LocalServiceTestHelper;
+import com.google.sps.Trip;
+import com.google.sps.data.User;
+import com.google.sps.servlets.MapServlet;
+import java.io.PrintWriter;
+import java.io.StringWriter;
+import javax.servlet.http.HttpServlet;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.util.ArrayList;
+import java.util.List;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+@RunWith(JUnit4.class)
+public final class MapServletTest {
+
+  private MapServlet mapServlet;
+
+  // class constants
+  private static final String INPUT_DESTINATION = 
+      "4265 24th Street San Francisco, CA, 94114";
+  private static final String INPUT_DATE = "2020-07-15";
+  private static final String EMAIL = "test123@gmail.com";
+
+  // Constants to represent different Trip attributes.
+  private static final String TRIP_NAME = "Trip to California";
+  private static final String DESTINATION_NAME = "California";
+  private static final String IMAGE_SRC =
+    "https://lh3.googleusercontent.com/p/AF1QipM7tbCZOj_5SOft9cYgI7un3bmieieqvdYkCPT5=s1600-w400";
+  private static final String TRIP_DAY_OF_TRAVEL = "2020-02-29";
+
+  // location constants
+  private static final String DOME_ADDRESS = "Half Dome Visor";
+  private static final String YOSEMITE_ADDRESS = "Upper Yosemite Fall";
+
+  private final LocalServiceTestHelper helper =
+      new LocalServiceTestHelper(new LocalDatastoreServiceTestConfig());
+
+  @Before
+  public void initMapServlet() {
+    mapServlet = new MapServlet();
+  }
+
+  @Before
+  public void setUp() {
+    helper.setUp();
+  }
+
+  @After
+  public void tearDown() {
+    helper.tearDown();
+  }
+
+  /* 
+   * Tests that doGet constructs the expected JSON string containing locations in order
+   */
+  @Test
+  public void testWriteLocations() throws Exception {
+    HttpServletRequest request = mock(HttpServletRequest.class);       
+    HttpServletResponse response = mock(HttpServletResponse.class);    
+
+    // Create writers to check against actual output.
+    StringWriter stringWriter = new StringWriter();
+    PrintWriter writer = new PrintWriter(stringWriter);
+    when(response.getWriter()).thenReturn(writer);
+
+    // initialize datastore
+    DatastoreService datastore = DatastoreServiceFactory.getDatastoreService();
+
+    // create user entity
+    Entity userEntity = new Entity(User.USER);
+    userEntity.setProperty(User.USER_EMAIL, EMAIL);
+    datastore.put(userEntity);
+    Key userEntityKey = userEntity.getKey();
+
+    // Add a single Trip to Datastore with the User Entity Key.
+    Entity tripEntity = new Entity(Trip.TRIP, userEntityKey);
+    tripEntity.setProperty(Trip.TRIP_NAME, TRIP_NAME);
+    tripEntity.setProperty(Trip.DESTINATION_NAME, DESTINATION_NAME);
+    tripEntity.setProperty(Trip.IMAGE_SRC, IMAGE_SRC);
+    tripEntity.setProperty(Trip.START_DATE, TRIP_DAY_OF_TRAVEL);
+    tripEntity.setProperty(Trip.END_DATE, TRIP_DAY_OF_TRAVEL);
+    datastore.put(tripEntity);
+
+    // create tripDay entity
+    Entity tripDayEntity = new Entity(TripDay.QUERY_STRING, tripEntity.getKey());
+    tripDayEntity.setProperty("origin", INPUT_DESTINATION);
+    tripDayEntity.setProperty("destination", INPUT_DESTINATION);
+    tripDayEntity.setProperty("date", INPUT_DATE);
+    datastore.put(tripDayEntity);
+
+    // create location entities and put it into datastore
+    Entity DomeEntity = new Entity(TripDay.LOCATION_ENTITY_TYPE, tripDayEntity.getKey());
+    DomeEntity.setProperty(TripDay.NAME, DOME_ADDRESS);
+    DomeEntity.setProperty(TripDay.ORDER, 1);
+    datastore.put(DomeEntity);
+
+    Entity YosemiteEntity = new Entity(TripDay.LOCATION_ENTITY_TYPE, tripDayEntity.getKey());
+    YosemiteEntity.setProperty(TripDay.NAME, YOSEMITE_ADDRESS);
+    YosemiteEntity.setProperty(TripDay.ORDER, 0);
+    datastore.put(YosemiteEntity);
+
+    // run do Get
+    mapServlet.doGetMap(response, datastore, userEntity, tripEntity.getKey());
+
+    String expectedJson = "[\"" + INPUT_DESTINATION + "\",\""+YOSEMITE_ADDRESS+"\",\""+DOME_ADDRESS+"\"]";
+    
+    writer.flush();
+    Assert.assertTrue(stringWriter.toString().contains(expectedJson));
+  }
+
+  /* 
+   * Tests doGet when there is no current user
+   */
+  @Test
+  public void testNoCurrentUser() throws Exception {
+    HttpServletRequest request = mock(HttpServletRequest.class);       
+    HttpServletResponse response = mock(HttpServletResponse.class);  
+
+    when(request.getParameter("tripKey")).thenReturn("true");
+
+    // Create writers to check against actual output.
+    StringWriter stringWriter = new StringWriter();
+    PrintWriter writer = new PrintWriter(stringWriter);
+    when(response.getWriter()).thenReturn(writer);
+
+    mapServlet.doGet(request, response);
+
+    String expectedJson = "No current User";
+    Assert.assertTrue(stringWriter.toString().contains(expectedJson));
+  }
+
+  /* 
+   * Tests doGet when there is no trip key
+   */
+  @Test
+  public void testNoTripKeyPassedIn() throws Exception {
+    HttpServletRequest request = mock(HttpServletRequest.class);       
+    HttpServletResponse response = mock(HttpServletResponse.class); 
+
+    // Create writers to check against actual output.
+    StringWriter stringWriter = new StringWriter();
+    PrintWriter writer = new PrintWriter(stringWriter);
+    when(response.getWriter()).thenReturn(writer);
+
+    // initialize datastore
+    DatastoreService datastore = DatastoreServiceFactory.getDatastoreService();
+
+    // create user entity
+    Entity userEntity = new Entity(User.USER);
+    userEntity.setProperty(User.USER_EMAIL, EMAIL);
+    datastore.put(userEntity);
+
+    mapServlet.doGet(request, response);
+
+    String expectedJson = "No trip Key";
+    Assert.assertTrue(stringWriter.toString().contains(expectedJson));
+  }
+}

--- a/src/test/java/com/google/sps/MapServletTest.java
+++ b/src/test/java/com/google/sps/MapServletTest.java
@@ -164,6 +164,7 @@ public final class MapServletTest {
   public void testNoTripKeyPassedIn() throws Exception {
     HttpServletRequest request = mock(HttpServletRequest.class);       
     HttpServletResponse response = mock(HttpServletResponse.class); 
+    when(request.getParameter("tripKey")).thenReturn(null);
 
     // Create writers to check against actual output.
     StringWriter stringWriter = new StringWriter();


### PR DESCRIPTION
This is the last CL for the MVP! This CL completes the maps functionality of TravIS by fetching the trip's locations (in optimized order) from Datastore and displaying the optimal route to travel to each of these locations on the maps page.

**List of Changes:**
1. Add `MapServlet.java` which is called by the maps page to fetch the correct Trip and TripDay's locations from Datastore in optimized order as a JSON object.
2. Test MapServlet functions in `MapServletTest.java`.
3. Modify `mapsScript.js` to fetch the locations from the servlet, parse them, generate a DirectionsRequest with the locations, and display the computed route on the map.

**Note:** 
While testing I noticed that the website will throw an exception if the user inputs locations such that a route cannot be generated. While the user can simply go back and try creating a new trip, I plan to handle this error better post-MVP so that the user can clearly understand what went wrong and we can automatically redirect them back to the create trips page.