### PR TITLE
Add popups and markers.

### DIFF
--- a/src/main/webapp/mapsScript.js
+++ b/src/main/webapp/mapsScript.js
@@ -157,7 +157,7 @@ function addInfoWindow(results, marker) {
   const urlFormatAddress = results[0].name.replace(/\s/g, '+');
   const url = 'https://www.google.com/maps/search/?api=1&query=' + urlFormatAddress 
               + '&query_place_id=' + results[0].placeId;
-  contentString += "<a href=\""+url+"\">View on Google Maps</a>";
+  contentString += "<a href=\""+url+"\" target=\"_blank\">View on Google Maps</a>";
   // Construct infoWindow.
   const infoWindow = new google.maps.InfoWindow({
     content: contentString,

--- a/src/main/webapp/mapsScript.js
+++ b/src/main/webapp/mapsScript.js
@@ -23,9 +23,8 @@ var map;
 var directionsService;
 var directionsRenderer;
 
-// Map marker label constants
+// Map marker label constant
 var labels = 'ABCDEFGHIJKLMNOPQRSTUVWXYZ';
-var labelIndex = 1;
 
 // Attach callback function to the `window` object
 window.initMap = function() {

--- a/src/main/webapp/mapsScript.js
+++ b/src/main/webapp/mapsScript.js
@@ -151,16 +151,32 @@ function addPoiMarker(location, isOrigin, index) {
  */
 function addInfoWindow(results, marker) {
   // Format and add place name, address, and link to Google Maps.
-  let contentString = "";
-  contentString += "<b>" + results[0].name + "</b>";
-  contentString += "<p>" + results[0].formatted_address + "</p>";
+  const info = document.createElement('div');
+  info.id = 'infoWindow';
+
+  // Add place name in bold.
+  const boldName = document.createElement('b');
+  boldName.innerText = results[0].name;
+  info.appendChild(boldName);
+
+  // Add formatted address.
+  const address = document.createElement('p');
+  address.innerText = results[0].formatted_address;
+  info.appendChild(address);
+
+  // Add link to Google Maps.
   const urlFormatAddress = results[0].name.replace(/\s/g, '+');
   const url = 'https://www.google.com/maps/search/?api=1&query=' + urlFormatAddress 
               + '&query_place_id=' + results[0].placeId;
-  contentString += "<a href=\""+url+"\" target=\"_blank\">View on Google Maps</a>";
+  const link = document.createElement('a');
+  link.href = url;
+  link.target = '_blank';
+  link.innerText = 'View on Google Maps';
+  info.appendChild(link);
+
   // Construct infoWindow.
   const infoWindow = new google.maps.InfoWindow({
-    content: contentString,
+    content: info,
     maxWidth: 200
   });
   // Open/close infoWindow on marker click.

--- a/src/main/webapp/mapsScript.js
+++ b/src/main/webapp/mapsScript.js
@@ -23,6 +23,10 @@ var map;
 var directionsService;
 var directionsRenderer;
 
+// Map marker label constants
+var labels = 'ABCDEFGHIJKLMNOPQRSTUVWXYZ';
+var labelIndex = 1;
+
 // Attach callback function to the `window` object
 window.initMap = function() {
   // initialize coords
@@ -40,7 +44,7 @@ window.initMap = function() {
   directionsService = new google.maps.DirectionsService;
 
   // Create a renderer for directions (shows directions on map and panel).
-  directionsRenderer = new google.maps.DirectionsRenderer;
+  directionsRenderer = new google.maps.DirectionsRenderer({suppressMarkers: true});
   directionsRenderer.setMap(map);
   directionsRenderer.setPanel(document.getElementById('rightPanel'));
 
@@ -89,6 +93,93 @@ function showDirections(locations) {
     } else {
       window.alert('Directions request failed due to ' + status);
     }
+  });
+
+  // Add markers to map.
+  addPoiMarker(origin, true, 0);  
+  for (let i = 0; i < waypts.length; i++) {
+    let index = i + 1;
+    addPoiMarker(waypts[i].location, false, index);
+  }
+}
+
+/* 
+ * Adds marker to map with appropriate letter label and an info window.
+ * location: String name or address of the POI.
+ * isOrigin: boolean indicating if the location is the origin (hotel) or not.
+             Used to determine the icon of the map marker.
+ * index: index of waypoint. Used to determine marker label.
+ */
+function addPoiMarker(location, isOrigin, index) {
+  // Query the location String to get Place details.
+  var service = new google.maps.places.PlacesService(map);
+  service.textSearch({
+    location: map.getCenter(),
+    radius: '500',
+    query: location
+    }, function(results, status) {
+      if (status == google.maps.places.PlacesServiceStatus.OK) {
+        // Add marker to map.
+        let marker = new google.maps.Marker({
+          map: map,
+          place: {
+            placeId: results[0].place_id,
+            location: results[0].geometry.location
+          },
+        });
+        // Change icon to green if the location is the origin.
+        if (isOrigin) {
+          marker.setIcon("http://maps.google.com/mapfiles/ms/icons/green-dot.png");
+        } else {
+          marker.setLabel({
+            color: "white",
+            // Set text to correct letter label.
+            text: labels[index % labels.length]
+          });
+        } 
+        // Add info window to marker.     
+        addInfoWindow(results, marker);
+      } else {
+        alert(status);
+        return;
+      }
+  });
+}
+
+/* 
+ * Adds info window to a marker.
+ * Info window includes place name, address, and link to Google Maps.
+ */
+function addInfoWindow(results, marker) {
+  // Format and add place name, address, and link to Google Maps.
+  let contentString = "";
+  contentString += "<b>" + results[0].name + "</b>";
+  contentString += "<p>" + results[0].formatted_address + "</p>";
+  const urlFormatAddress = results[0].name.replace(/\s/g, '+');
+  const url = 'https://www.google.com/maps/search/?api=1&query=' + urlFormatAddress 
+              + '&query_place_id=' + results[0].placeId;
+  contentString += "<a href=\""+url+"\">View on Google Maps</a>";
+  // Construct infoWindow.
+  const infoWindow = new google.maps.InfoWindow({
+    content: contentString,
+    maxWidth: 200
+  });
+  // Open/close infoWindow on marker click.
+  let infoWindowOpen = false;
+  marker.addListener("click", () => {
+    if (infoWindowOpen) {
+      infoWindow.close();
+      infoWindowOpen = false;
+    }
+    else {
+      infoWindow.open(map, marker);
+      infoWindowOpen = true;            
+    }
+  });
+  // Close infoWindow on map click.
+  map.addListener("click", () => {
+    infoWindow.close();
+    infoWindowOpen = false;
   });
 }
 

--- a/src/main/webapp/mapsScript.js
+++ b/src/main/webapp/mapsScript.js
@@ -169,8 +169,7 @@ function addInfoWindow(results, marker) {
     if (infoWindowOpen) {
       infoWindow.close();
       infoWindowOpen = false;
-    }
-    else {
+    } else {
       infoWindow.open(map, marker);
       infoWindowOpen = true;            
     }

--- a/src/main/webapp/mapsScript.js
+++ b/src/main/webapp/mapsScript.js
@@ -96,6 +96,7 @@ function showDirections(locations) {
 
   // Add markers to map.
   addPoiMarker(origin, true, 0);  
+  // Markers must be added after map is recentered by directionsRenderer (above).
   for (let i = 0; i < waypts.length; i++) {
     let index = i + 1;
     addPoiMarker(waypts[i].location, false, index);
@@ -114,7 +115,7 @@ function addPoiMarker(location, isOrigin, index) {
   var service = new google.maps.places.PlacesService(map);
   service.textSearch({
     location: map.getCenter(),
-    radius: '500',
+    radius: '50000',
     query: location
     }, function(results, status) {
       if (status == google.maps.places.PlacesServiceStatus.OK) {


### PR DESCRIPTION
This CL makes the map on the maps page more intuitive for the user by distinguishing the hotel marker from the POI markers and adding info popups to each of the markers.

Note: Because I am now querying the locations and adding the markers based on the place IDs from that query, not all the markers are perfectly on the route. However, the marker locations are still in the vicinity and tend to correspond to the central point of the location so I believe this is fine.