### PR TITLE
Add static content to the edit page, create text input with auto-changed size.

### DIFF
--- a/src/main/webapp/edit.html
+++ b/src/main/webapp/edit.html
@@ -123,7 +123,7 @@
                   <input class="autoscale-text edit-card-title-size" type="text" value="Woodland Park Zoo">
                   <i class="fa fa-edit edit-card-icon"></i>
                   <p class="edit-card-text">5500 Phinney Avenue North, Seattle</p>
-                  <p class="edit-card-text">10AM - 11AM</p>
+                  <p class="edit-card-text">11:10AM - 12:10PM</p>
                 </div>
                 <i class="fa fa-trash edit-card-delete"></i>
                 <button type="button" class="btn btn-primary-dark btn-sm edit-card-changed-button changed-button">Changed</button>

--- a/src/main/webapp/edit.html
+++ b/src/main/webapp/edit.html
@@ -62,13 +62,74 @@
                   name="inputPoi" autocomplete="off">
               </div>
               <div class="form-group sidebar-input-form">
+                <button class="btn-nohover btn-light-nohover" type="button">
+                  <span class="poi-input" id="poi-element-text">Gas Works Park</span>
+                  <span id="poi-element-space">&nbsp;&nbsp;&nbsp;&nbsp;</span>
+                  <i id="poi-trash-icon" class="fa fa-trash"></i>
+                </button>
+              </div>
+              <div class="form-group sidebar-input-form">
                 <input type="button" class="btn btn-primary" value="Add POI">
+              </div>
+              <hr>
+              <p class="sidebar-p">Save the changes you've made so far.</p>
+              <div class="form-group sidebar-input-form">
+                <input type="button" class="btn btn-success" value="Save Trip">
+              </div>
+              <hr>
+              <h4 class="sidebar-header">Danger Zone</h4>
+              <p class="sidebar-p">Deleting the trip cannot be undone.</p>
+              <div class="form-group sidebar-input-form" id="delete-trip-button-container">
+                <input type="button" class="btn btn-danger" value="Delete Trip">
               </div>
             </div>
           </div>
         </div>
         <div class="col" id="edit-page-left-column">
-          <h1>Example Trip Name</h1>
+          <span class="autoscale-hide-span edit-trip-title-size"></span>
+          <input class="autoscale-text edit-trip-title-size" type="text" value="My Favorite Trip">
+          <i class="fa fa-edit edit-trip-icon"></i>
+          <button type="button" class="btn btn-primary-dark btn-sm changed-button-display">Changed</button>
+          <div class="form-group col-md-4" id="inputDayOfTravelContainer">
+            <label for="inputDayOfTravel">Day Of Travel</label>
+            <input type="date" class="form-control" name="inputDayOfTravel" value="2020-08-15">
+          </div>
+          <h1>Saturday, 8/15</h1>
+          <div class="card edit-card">
+            <div class="row no-gutters edit-card-height">
+              <div class="col-sm-4 edit-card-height">
+                <img class="card-img edit-card-height" src="https://lh3.googleusercontent.com/p/AF1QipPywZEmLPoz_sxqzb6UD4--PwLrTugFDHUTA9TR=s1600-w1932" alt="Space Needle">
+              </div>
+              <div class="col-sm-8">
+                <div class="card-body edit-card-align">
+                  <span class="autoscale-hide-span edit-card-title-size">Space Needle</span>
+                  <input class="autoscale-text edit-card-title-size" type="text" value="Space Needle">
+                  <i class="fa fa-edit edit-card-icon"></i>
+                  <p class="edit-card-text">400 Broad Street, Seattle</p>
+                  <p class="edit-card-text">10AM - 11AM</p>  
+                </div>
+                <i class="fa fa-trash edit-card-delete"></i>
+              </div>
+            </div>
+          </div>
+          <div class="card edit-card">
+            <div class="row no-gutters edit-card-height">
+              <div class="col-sm-4 edit-card-height">
+                <img class="card-img edit-card-height" src="https://lh3.googleusercontent.com/p/AF1QipNcuesYJkpIpPg1MgSYBRxOUVh8eTswgtTLywhw=s1600-w6000" alt="Space Needle">
+              </div>
+              <div class="col-sm-8">
+                <div class="card-body edit-card-align">
+                  <span class="autoscale-hide-span edit-card-title-size">Woodland Park Zoo</span>
+                  <input class="autoscale-text edit-card-title-size" type="text" value="Woodland Park Zoo">
+                  <i class="fa fa-edit edit-card-icon"></i>
+                  <p class="edit-card-text">5500 Phinney Avenue North, Seattle</p>
+                  <p class="edit-card-text">10AM - 11AM</p>
+                </div>
+                <i class="fa fa-trash edit-card-delete"></i>
+                <button type="button" class="btn btn-primary-dark btn-sm edit-card-changed-button">Changed</button>
+              </div>
+            </div>
+          </div>
         </div>
       </div>
     </div>

--- a/src/main/webapp/edit.html
+++ b/src/main/webapp/edit.html
@@ -89,7 +89,7 @@
           <span class="autoscale-hide-span edit-trip-title-size"></span>
           <input class="autoscale-text edit-trip-title-size" type="text" value="My Favorite Trip">
           <i class="fa fa-edit edit-trip-icon"></i>
-          <button type="button" class="btn btn-primary-dark btn-sm changed-button-display">Changed</button>
+          <button type="button" class="btn btn-primary-dark btn-sm changed-button">Changed</button>
           <div class="form-group col-md-4" id="inputDayOfTravelContainer">
             <label for="inputDayOfTravel">Day Of Travel</label>
             <input type="date" class="form-control" name="inputDayOfTravel" value="2020-08-15">
@@ -126,7 +126,7 @@
                   <p class="edit-card-text">10AM - 11AM</p>
                 </div>
                 <i class="fa fa-trash edit-card-delete"></i>
-                <button type="button" class="btn btn-primary-dark btn-sm edit-card-changed-button">Changed</button>
+                <button type="button" class="btn btn-primary-dark btn-sm edit-card-changed-button changed-button">Changed</button>
               </div>
             </div>
           </div>

--- a/src/main/webapp/edit.html
+++ b/src/main/webapp/edit.html
@@ -13,6 +13,7 @@
     <script src="https://stackpath.bootstrapcdn.com/bootstrap/4.1.3/js/bootstrap.min.js" integrity="sha384-ChfqqxuZUCnJSK3+MXmPNIyE6ZbWh2IMqE241rYiqJxyMiZ6OW/JmZQ5stwEULTy" crossorigin="anonymous"></script>
     <link rel="stylesheet" href="style.css">
     <script src="config.js"></script>
+    <script src="utility.js"></script>
     <script src="editScript.js"></script>
     <script src="authScript.js"></script>
     <script src="createNavLinks.js"></script>

--- a/src/main/webapp/editScript.js
+++ b/src/main/webapp/editScript.js
@@ -22,6 +22,7 @@ script.async = true;
 // Attach callback function to the 'window' object.
 window.initEditScript = () => {
   addInputPoiLocationAutofill();
+  autoscaleTextInputWidth();
 }
 
 // Add text input POI Google Places autofill.
@@ -41,6 +42,33 @@ function addInputPoiLocationAutofill() {
     inputPoi.classList.add('is-valid');
   });
 }
+
+/**
+ * Autoscale the text input width for the edit text inputs.
+ */
+function autoscaleTextInputWidth() {
+  // Get the autoscale text input elements.
+  const autoscaleHideSpans = $('.autoscale-hide-span');
+  const autoscaleTextEls = $('.autoscale-text');
+
+  for (let i = 0; i < autoscaleHideSpans.length; i++) {
+    // Set constants for adding to (for some reason, it's slightly short)
+    // and scaling the width.
+    const autoscaleHideSpan = $(autoscaleHideSpans[i]);
+    const autoscaleText = $(autoscaleTextEls[i]);
+
+    // Set the initial width of the text input.
+    autoscaleHideSpan.text(autoscaleText.val());
+    autoscaleText.width(autoscaleHideSpan.width());
+
+    // Readjust text input width upon edit.
+    autoscaleText.on('input', () => {
+      autoscaleHideSpan.text(autoscaleText.val());
+      autoscaleText.width(autoscaleHideSpan.width());
+    });
+  }
+}
+
 
 // Append the 'script' element to the document head.
 document.head.appendChild(script);

--- a/src/main/webapp/script.js
+++ b/src/main/webapp/script.js
@@ -453,7 +453,7 @@ function addSuggestedLocations(suggestedLocations) {
 function buildSuggestedLocationWidget(name, vicinity, photoSrc) {
   // The container that holds the full card.
   const cardContainer = document.createElement('div');
-  cardContainer.className = 'card';
+  cardContainer.className = 'card main-card';
 
   // Add the photo of this location.
   const photoElement = document.createElement('img');

--- a/src/main/webapp/style.css
+++ b/src/main/webapp/style.css
@@ -53,7 +53,7 @@
 }
 
 #rightPanel {
-  font-family: 'maven-pro';
+  /* font-family: 'maven-pro'; */
   line-height: 30px;
   padding-left: 10px;
   height: 500px;
@@ -147,7 +147,7 @@
   margin: 20px 0;
 }
 
-.card {
+.main-card {
   display: inline-flex;
   width: 30%;
   height: 400px;
@@ -297,10 +297,110 @@ input[type=date] {
   margin-bottom: 0px;
 }
 
+.sidebar-p {
+  margin-top: 0;
+  margin-bottom: 0.5rem;
+  line-height: 1.3;
+}
+
 .sidebar-input-form {
   padding: 0px;
+}
+
+hr {
+  margin: 8px 0px 16px 0px;
+  border: 2px solid #ededed;
+  width: 100%;
+  border-top: none;
 }
 
 #edit-page-left-column {
   padding: 40px;
 }
+
+.autoscale-text {
+  border: none;
+  border-bottom: 1px solid black;
+  min-width: 10px;
+  margin-bottom: 5px;
+}
+
+#inputDayOfTravelContainer {
+  margin: 20px 0;
+}
+
+.edit-card {
+  display: block;
+  width: 90%;
+  margin: 0px;
+  margin-top: 20px;
+  height: 200px;
+  box-shadow: 0 5px 5px 0 rgba(0,0,0,0.2), 0 6px 15px 0 rgba(0,0,0,0.19);
+}
+
+.edit-trip-title-size {
+  font-size: 2.5rem;
+}
+
+.edit-trip-icon {
+  font-size: 2rem;
+  margin-left: 5px;
+}
+
+.edit-card-title-size {
+  font-size: 1.5rem;
+}
+
+.edit-card-icon {
+  font-size: 1.25rem;
+  margin-left: 5px;
+}
+
+.edit-card-text {
+  font-size: 1.25rem;
+  margin: 0.5rem 0;
+}
+
+.edit-card-delete {
+  font-size: 1.5rem;
+  position: absolute;
+  top: 1.5rem;
+  right: 1.5rem;
+}
+
+.edit-card-changed-button {
+  position: absolute;
+  bottom: 1.25rem;
+  left: 1.25rem;
+}
+
+.edit-card-height {
+  height: 200px;
+}
+
+.edit-card-align {
+  text-align: left;
+}
+
+.changed-button-display {
+  display: block;
+}
+
+.autoscale-hide-span {
+  display: none;
+  white-space: pre;
+}
+
+.btn-sm {
+  padding: .15rem .3rem;
+  font-size: .75rem;
+  line-height: 1.5;
+  border-radius: .2rem;
+}
+
+.btn-primary-dark {
+  color: #fff;
+  background-color: #3c78d8ff;
+  border-color: #3c78d8ff;
+}
+

--- a/src/main/webapp/style.css
+++ b/src/main/webapp/style.css
@@ -340,6 +340,7 @@ hr {
 
 .edit-trip-title-size {
   font-size: 2.5rem;
+  max-width: 500px;
 }
 
 .edit-trip-icon {
@@ -349,6 +350,7 @@ hr {
 
 .edit-card-title-size {
   font-size: 1.5rem;
+  max-width: 300px;
 }
 
 .edit-card-icon {
@@ -382,8 +384,9 @@ hr {
   text-align: left;
 }
 
-.changed-button-display {
+.changed-button {
   display: block;
+  color: white!important;
 }
 
 .autoscale-hide-span {

--- a/src/main/webapp/style.css
+++ b/src/main/webapp/style.css
@@ -53,7 +53,6 @@
 }
 
 #rightPanel {
-  /* font-family: 'maven-pro'; */
   line-height: 30px;
   padding-left: 10px;
   height: 500px;

--- a/src/main/webapp/trips/tripScript.js
+++ b/src/main/webapp/trips/tripScript.js
@@ -89,7 +89,7 @@ function addTripCards(trips) {
 function buildTripCard(tripTitle, destinationName, imageSrc, startDate, endDate, tripKey) {
   // Create the card container.
   const cardContainer = document.createElement('div');
-  cardContainer.className = 'card';
+  cardContainer.className = 'card main-card';
 
   // Create a trip image object (image of the destination).
   const tripImage = document.createElement('img');


### PR DESCRIPTION
(This branch is being merged into **EditPageContent** because that branch has the edit page structure that is needed.)

### List of changes:
- Add content to the sidebar and body (left side) of the Edit page.
  - Add **Save Trip** and **Delete Trip** buttons, as well as the temporarily-added POI button, to the sidebar.
  - Add the trip title, day of travel, and trip cards to the body.
- Create a **Changed** button which will be dynamically added to the page under any edited inputs.
- Create a JavaScript function to have the text inputs match the size of the text. (Note: There is no built-in function to do this, so I had to do it dynamically.)
- Create a card style used for visited POIs with the image on the left, and the text / information on the right.

### Notes:
- Currently, the Edit body content is static / hard-coded. On later CLs, however, this content will be dynamically added.
- The **Changed** button will only appear once the corresponding input element is edited. Right now, however, I added it to two random elements -- the trip title and the second trip card.
- Eventually, the trash can and edit icons will be clickable / actionable.
- When the page is refreshed with a cache-clear (`ctrl + shift + r`), the input text size doesn't match the actual text size. However, on any other situation, the input text size is correct. I don't know what causes this error, but it's fixed as soon as the user modifies the text.

### Screencast:
[Add Edit Page Content](https://screencast.googleplex.com/cast/NTE4NDYwODQ5NDY4MjExMnw3YWExOTMwMS0zZg)

### Images:
Image of the Edit page:
![image](https://user-images.githubusercontent.com/7987279/89139277-0852b180-d4f3-11ea-980c-f8b258b0558c.png)
